### PR TITLE
Use filepath.Join instead of fmt.Sprintf for joining paths

### DIFF
--- a/render.go
+++ b/render.go
@@ -2,10 +2,10 @@ package pages
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 )
 
@@ -38,15 +38,15 @@ func SetViewsDir(dirname string) {
 func parseTemplates(baseDir string) (*template.Template, error) {
 	var allFiles []string
 
-	sharedDir := fmt.Sprintf("./%s/shared/", viewsDir)
-	layoutsDir := fmt.Sprintf("./%s/layout/", viewsDir)
-	templatesDir := fmt.Sprintf("./%s/%s/", viewsDir, baseDir)
+	sharedDir := filepath.Join(viewsDir, "shared")
+	layoutsDir := filepath.Join(viewsDir, "layout")
+	templatesDir := filepath.Join(viewsDir, baseDir)
 
 	if layouts, err := ioutil.ReadDir(layoutsDir); err == nil {
 		for _, file := range layouts {
 			filename := file.Name()
 			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, layoutsDir+filename)
+				allFiles = append(allFiles, filepath.Join(layoutsDir, filename))
 			}
 		}
 	} else {
@@ -57,7 +57,7 @@ func parseTemplates(baseDir string) (*template.Template, error) {
 		for _, file := range shared {
 			filename := file.Name()
 			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, sharedDir+filename)
+				allFiles = append(allFiles, filepath.Join(sharedDir, filename))
 			}
 		}
 	} else {
@@ -68,7 +68,7 @@ func parseTemplates(baseDir string) (*template.Template, error) {
 		for _, file := range files {
 			filename := file.Name()
 			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, templatesDir+filename)
+				allFiles = append(allFiles, filepath.Join(templatesDir, filename))
 			}
 		}
 	} else {

--- a/render.go
+++ b/render.go
@@ -36,46 +36,49 @@ func SetViewsDir(dirname string) {
 }
 
 func parseTemplates(baseDir string) (*template.Template, error) {
-	var allFiles []string
+	var allFiles, dirFiles []string
 
 	sharedDir := filepath.Join(viewsDir, "shared")
 	layoutsDir := filepath.Join(viewsDir, "layout")
 	templatesDir := filepath.Join(viewsDir, baseDir)
 
-	if layouts, err := ioutil.ReadDir(layoutsDir); err == nil {
-		for _, file := range layouts {
-			filename := file.Name()
-			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, filepath.Join(layoutsDir, filename))
-			}
-		}
-	} else {
+	dirFiles, err := getTemplateFilenames(sharedDir)
+	if err != nil {
 		return nil, err
 	}
+	allFiles = append(allFiles, dirFiles...)
 
-	if shared, err := ioutil.ReadDir(sharedDir); err == nil {
-		for _, file := range shared {
-			filename := file.Name()
-			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, filepath.Join(sharedDir, filename))
-			}
-		}
-	} else {
+	dirFiles, err = getTemplateFilenames(layoutsDir)
+	if err != nil {
 		return nil, err
 	}
+	allFiles = append(allFiles, dirFiles...)
 
-	if files, err := ioutil.ReadDir(templatesDir); err == nil {
-		for _, file := range files {
-			filename := file.Name()
-			if strings.HasSuffix(filename, ".html") {
-				allFiles = append(allFiles, filepath.Join(templatesDir, filename))
-			}
-		}
-	} else {
+	dirFiles, err = getTemplateFilenames(templatesDir)
+	if err != nil {
 		return nil, err
 	}
+	allFiles = append(allFiles, dirFiles...)
 
 	return template.New("").Delims(leftDelimiter, rightDelimiter).ParseFiles(allFiles...)
+}
+
+func getTemplateFilenames(dir string) ([]string, error) {
+	var filenames []string
+
+	entries, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		filename := entry.Name()
+		if strings.HasSuffix(filename, ".html") {
+			filenames = append(filenames, filepath.Join(dir, filename))
+		}
+	}
+
+	return filenames, nil
 }
 
 func Render(writer io.Writer, page Page, tplDir string) error {

--- a/render.go
+++ b/render.go
@@ -36,31 +36,18 @@ func SetViewsDir(dirname string) {
 }
 
 func parseTemplates(baseDir string) (*template.Template, error) {
-	var allFiles, dirFiles []string
+	var templates []string
 
-	sharedDir := filepath.Join(viewsDir, "shared")
-	layoutsDir := filepath.Join(viewsDir, "layout")
-	templatesDir := filepath.Join(viewsDir, baseDir)
+	for _, dir := range []string{"shared", "layout", baseDir} {
+		files, err := getTemplateFilenames(filepath.Join(viewsDir, dir))
+		if err != nil {
+			return nil, err
+		}
 
-	dirFiles, err := getTemplateFilenames(sharedDir)
-	if err != nil {
-		return nil, err
+		templates = append(templates, files...)
 	}
-	allFiles = append(allFiles, dirFiles...)
 
-	dirFiles, err = getTemplateFilenames(layoutsDir)
-	if err != nil {
-		return nil, err
-	}
-	allFiles = append(allFiles, dirFiles...)
-
-	dirFiles, err = getTemplateFilenames(templatesDir)
-	if err != nil {
-		return nil, err
-	}
-	allFiles = append(allFiles, dirFiles...)
-
-	return template.New("").Delims(leftDelimiter, rightDelimiter).ParseFiles(allFiles...)
+	return template.New("").Delims(leftDelimiter, rightDelimiter).ParseFiles(templates...)
 }
 
 func getTemplateFilenames(dir string) ([]string, error) {


### PR DESCRIPTION
`fmt.Sprintf` won't work in all OSes and won't properly resolve some paths, whereas [`filepath.Join`](https://golang.org/pkg/path/filepath/#Join) has implementations for different OSes and will handle cleaning up the returned path.