### PR TITLE
Scope rendering to a struct

### DIFF
--- a/render.go
+++ b/render.go
@@ -12,6 +12,7 @@ import (
 var leftDelimiter = "{{"
 var rightDelimiter = "}}"
 var viewsDir = "./views"
+var layoutFileName = "application.html"
 
 type Page struct {
 	Title    string
@@ -33,6 +34,10 @@ func SetEscapeStrings(left, right string) {
 
 func SetViewsDir(dirname string) {
 	viewsDir = dirname
+}
+
+func SetLayoutName(layoutName string) {
+	lauyoutFileName = layoutName + ".html"
 }
 
 func parseTemplates(baseDir string) (*template.Template, error) {
@@ -81,7 +86,7 @@ func Render(writer io.Writer, page Page, tplDir string) error {
 
 	content := layoutContent{Page: page, Content: template.HTML(buf.String())}
 
-	templates.ExecuteTemplate(writer, "application.html", content)
+	templates.ExecuteTemplate(writer, layoutFileName, content)
 
 	return nil
 }

--- a/render.go
+++ b/render.go
@@ -9,16 +9,17 @@ import (
 	"strings"
 )
 
-var leftDelimiter = "{{"
-var rightDelimiter = "}}"
-var viewsDir = "./views"
-var layoutFileName = "application.html"
-
 type Page struct {
 	Title    string
 	Template string
 	Subject  interface{}
 	Context  interface{}
+}
+
+type Renderer struct {
+	leftDelimiter  string
+	rightDelimiter string
+	viewsDir       string
 }
 
 type layoutContent struct {
@@ -27,24 +28,24 @@ type layoutContent struct {
 	Content template.HTML
 }
 
-func SetEscapeStrings(left, right string) {
-	leftDelimiter = left
-	rightDelimiter = right
+func NewRenderer() *Renderer {
+	return &Renderer{viewsDir: "./views", leftDelimiter: "{{", rightDelimiter: "}}"}
 }
 
-func SetViewsDir(dirname string) {
-	viewsDir = dirname
+func (r *Renderer) SetEscapeStrings(left, right string) {
+	r.leftDelimiter = left
+	r.rightDelimiter = right
 }
 
-func SetLayoutName(layoutName string) {
-	lauyoutFileName = layoutName + ".html"
+func (r *Renderer) SetViewsDir(dirname string) {
+	r.viewsDir = dirname
 }
 
-func parseTemplates(baseDir string) (*template.Template, error) {
+func (r *Renderer) parseTemplates(baseDir string) (*template.Template, error) {
 	var templates []string
 
 	for _, dir := range []string{"shared", "layout", baseDir} {
-		files, err := getTemplateFilenames(filepath.Join(viewsDir, dir))
+		files, err := getTemplateFilenames(filepath.Join(r.viewsDir, dir))
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +53,7 @@ func parseTemplates(baseDir string) (*template.Template, error) {
 		templates = append(templates, files...)
 	}
 
-	return template.New("").Delims(leftDelimiter, rightDelimiter).ParseFiles(templates...)
+	return template.New("").Delims(r.leftDelimiter, r.rightDelimiter).ParseFiles(templates...)
 }
 
 func getTemplateFilenames(dir string) ([]string, error) {
@@ -73,10 +74,10 @@ func getTemplateFilenames(dir string) ([]string, error) {
 	return filenames, nil
 }
 
-func Render(writer io.Writer, page Page, tplDir string) error {
+func (r *Renderer) Render(writer io.Writer, page Page, tplDir string) error {
 	buf := bytes.NewBuffer([]byte{})
 
-	templates, err := parseTemplates(tplDir)
+	templates, err := r.parseTemplates(tplDir)
 
 	if err != nil {
 		return err
@@ -86,7 +87,7 @@ func Render(writer io.Writer, page Page, tplDir string) error {
 
 	content := layoutContent{Page: page, Content: template.HTML(buf.String())}
 
-	templates.ExecuteTemplate(writer, layoutFileName, content)
+	err = templates.ExecuteTemplate(writer, "application.html", content)
 
-	return nil
+	return err
 }


### PR DESCRIPTION
This PR moves the template rendering responsibility from the package to a struct.

This adds flexibility and allows different settings within a same application.

